### PR TITLE
Fix code scanning alert no. 6: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
+			 .csrf().and()
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Fixes [https://github.com/lwang1234/gasworkshop99/security/code-scanning/6](https://github.com/lwang1234/gasworkshop99/security/code-scanning/6)

To fix the problem, we need to enable CSRF protection in the `configure` method of the `WebSecurityConfig` class. This involves removing the call to `csrf().disable()` and ensuring that CSRF protection is properly configured. We should also review the rest of the security configuration to ensure that enabling CSRF protection does not interfere with other security measures.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
